### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/bats_tests.yml
+++ b/.github/workflows/bats_tests.yml
@@ -1,0 +1,16 @@
+name: Bats tests
+
+on: [push, pull_request]
+
+jobs:
+  bats-test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup BATS testing framework
+      uses: mig4/setup-bats@v1.0.1
+    - name: Check out the code
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Run the bats tests
+      run: bats bats_tests.sh

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,13 @@
+name: shellcheck
+
+on: [push, pull_request]
+
+# Based on documentation from https://github.com/azohra/shell-linter
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v1
+      - name: Run Shellcheck
+        uses: azohra/shell-linter@latest

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+[![Bats tests](https://github.com/UMM-CSci-Systems/git-bats-demo/workflows/Bats%20tests/badge.svg)](https://github.com/UMM-CSci-Systems/git-bats-demo/actions?query=workflow%3A%22Bats+tests%22)
+[![Shellcheck](https://github.com/UMM-CSci-Systems/git-bats-demo/workflows/shellcheck/badge.svg)](https://github.com/UMM-CSci-Systems/git-bats-demo/actions?query=workflow%3Ashellcheck)
+(The `shellcheck` badge should be passing when you "fork" this repo, but
+the `Bats test` badge will be marked as "failing" until you have successfully
+implement the target script.)
+
 # Simple `git` and `bats` demo
 
 This is a very simple repository (repo) that can be used to demonstrate the basics

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Bats tests](https://github.com/UMM-CSci-Systems/git-bats-demo/workflows/Bats%20tests/badge.svg)](https://github.com/UMM-CSci-Systems/git-bats-demo/actions?query=workflow%3A%22Bats+tests%22)
-[![Shellcheck](https://github.com/UMM-CSci-Systems/git-bats-demo/workflows/shellcheck/badge.svg)](https://github.com/UMM-CSci-Systems/git-bats-demo/actions?query=workflow%3Ashellcheck)
+[![Bats tests](../../workflows/Bats%20tests/badge.svg)](../../actions?query=workflow%3A%22Bats+tests%22)
+[![Shellcheck](../../workflows/shellcheck/badge.svg)](../../actions?query=workflow%3Ashellcheck)
 (The `shellcheck` badge should be passing when you "fork" this repo, but
 the `Bats test` badge will be marked as "failing" until you have successfully
 implement the target script.)


### PR DESCRIPTION
This adds GitHub Actions for both the `bats` tests and `shellcheck`.

It also adds repo independent badges that should work when someone "forks" this repo.

Closes #5 