### PR TITLE
Fix submodule problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,7 @@ you can change the code, add collaborators, etc.
 
 <details>
   <summary>
-  
   :warning: Don't use "Use this template"
-  
   </summary>
   
   Bats (and thus this project) depend heavily on `git` submodules, which
@@ -188,12 +186,19 @@ Once that's all done you can clone the project:
 * In your terminal type `git clone --recurse-submodules <url>`, where `<url>` is the
   URL that you copied from Github.
 
-:information_source: &nbsp; You usually don't need the `--recurse-submodules` flag to
-`git clone`. Bats, however, uses submodules to load additional libraries,
-like `bats-file` which provides assertions about files. Our use of Bats
-here include dependence on three Bats libraries as `git` sub-modules, and
-including the `--recurse-submodules` flag ensures that those Bats
-dependencies will be properly included and your tests should run.
+<details>
+  <summary>
+  :information_source: &nbsp; You usually don't need the `--recurse-submodules` 
+  flag to `git clone`.
+  </summary>
+  
+  Bats, however, uses submodules to load additional libraries,
+  like `bats-file` which provides assertions about files. Our use of Bats
+  here include dependence on three Bats libraries as `git` sub-modules, and
+  including the `--recurse-submodules` flag ensures that those Bats
+  dependencies will be properly included and your tests should run.
+
+</details>
 
 This should clone a working copy of your fork of the repo onto your computer.
 You should probably confirm that you got the directories and files on your

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a very simple repository (repo) that can be used to demonstrate
 the basics of `git` and Github, as well as the `bats` unit testing tool
 for `bash` shell scripts.
 
-The idea here is to fork this repo, and then use the provided `bats` tests and
+The idea here is to fork (copy) this repo, and then use the provided `bats` tests and
 test-driven development (TDD) to incrementally build up a solution to a
 (simple) problem.
 
@@ -128,11 +128,19 @@ has links to lots of resources.
 
 ### Fork the repo
 
-Start by [creating a repository from our template](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template)
-by clicking the "Use this template" button near the top
+Start by [forking this repo](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo)
+by clicking the "Fork" button near the top
 right of the Github page for this repo. This creates a copy of the project
 _on Github_ that belongs to you. You'll have full permissions on this copy so
 you can change the code, add collaborators, etc.
+
+<details>
+  <summary>:warning: Don't use "Use this template"</summary>
+  Bats (and thus this project) depend heavily on `git` submodules, which
+  don't work properly with GitHub templates. So make sure you use "Fork"
+  instead of "Use this template" to create your copy of the repository
+  on GitHub.
+</details>
 
 ### Add collaborators
 
@@ -171,15 +179,18 @@ Once that's all done you can clone the project:
 * Get the clone link by clicking the "Code" button/dropdown menu (next to the
   green "Use this template" button), and then copying the URL in the little
   popup window.
-* In your terminal type `git clone --submodules <url>`, where `<url>` is the
+* In your terminal type `git clone --recurse-submodules <url>`, where `<url>` is the
   URL that you copied from Github.
 
-:information_source: You usually don't need the `--submodules` flag to
-`git clone`. Bats, however, uses submodules to load additional libraries,
-like `bats-file` which provides assertions about files. Our use of Bats
-here include dependence on three Bats libraries as `git` sub-modules, and
-including the `--submodules` flag ensures that those Bats dependencies will
-be properly included and your tests should run.
+<details>
+  <summary>:information_source: You usually don't need the `--recurse-submodules` flag to
+`git clone`.</summary>
+  Bats, however, uses submodules to load additional libraries,
+  like `bats-file` which provides assertions about files. Our use of Bats
+  here include dependence on three Bats libraries as `git` sub-modules, and
+  including the `--recurse-submodules` flag ensures that those Bats
+  dependencies will be properly included and your tests should run.
+</details>
 
 This should clone a working copy of your fork of the repo onto your computer.
 You should probably confirm that you got the directories and files on your

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ learn more.
 * [Pre-requisites](#pre-requisites)
 * [Setting up the repo](#setting-up-the-repo)
   * [Fork the repo](#fork-the-repo)
+  * [Enable GitHub Actions](#enable-github-actions)
   * [Add collaborators](#add-collaborators)
   * [Clone the repo on your computer](#clone-the-repo-on-your-computer)
     * [Setting up a project location](#setting-up-a-project-location)
@@ -146,6 +147,28 @@ you can change the code, add collaborators, etc.
 
 </details>
 
+### Enable GitHub Actions
+
+By default when you fork a repository like we just did, GitHub disables the
+associated GitHub Actions. We want to re-enable them, though, so you'll get
+the the continuous integration checks that both the tests pass and that
+`shellcheck` is happy.
+
+If you click the "Actions" tab up near the top, you should see a big warning:
+
+> Workflows aren’t being run on this forked repository
+
+along with some info telling you that you should be careful about actions
+(which are essentially executable) code that you might "inherit" through
+forking. So you can trust that we haven't done anything malicious, or you
+can have a look at our actions in `.github/workflows/` and have confirm that
+we're not misbehaving. If you're comfortable, though, you can hit the big
+green button that says:
+
+> I understand my workflows, go ahead and enable them.
+
+Then when you make your next commit, that will trigger GitHub Actions.
+
 ### Add collaborators
 
 If you want to work on this with as a group and want other folks to have the
@@ -188,7 +211,7 @@ Once that's all done you can clone the project:
 
 <details>
   <summary>
-  :information_source: &nbsp; You usually don't need the `--recurse-submodules` 
+  :information_source: &nbsp; You usually don't need the `--recurse-submodules`
   flag to `git clone`.
   </summary>
   

--- a/README.md
+++ b/README.md
@@ -135,18 +135,6 @@ right of the Github page for this repo. This creates a copy of the project
 _on Github_ that belongs to you. You'll have full permissions on this copy so
 you can change the code, add collaborators, etc.
 
-<details>
-  <summary>
-  :warning: Don't use the "Use this template" button.
-  </summary>
-  
-  Bats (and thus this project) depend heavily on `git` submodules, which
-  don't work properly with GitHub templates. So make sure you use "Fork"
-  instead of "Use this template" to create your copy of the repository
-  on GitHub.
-
-</details>
-
 ### Enable GitHub Actions
 
 By default when you fork a repository like we just did, GitHub disables the
@@ -203,9 +191,8 @@ project.
 Once that's all done you can clone the project:
 
 * If necessary, go back to the "home" page for your fork of the repo on Github.
-* Get the clone link by clicking the "Code" button/dropdown menu (next to the
-  green "Use this template" button), and then copying the URL in the little
-  popup window.
+* Get the clone link by clicking the big green "Code" button/dropdown menu,
+  and then copying the URL in the little popup window.
 * In your terminal type `git clone --recurse-submodules <url>`, where `<url>` is the
   URL that you copied from Github.
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ you can change the code, add collaborators, etc.
 
 <details>
   <summary>
-  :warning: Don't use "Use this template"
+  :warning: Don't use the "Use this template" button.
   </summary>
   
   Bats (and thus this project) depend heavily on `git` submodules, which
@@ -192,11 +192,12 @@ Once that's all done you can clone the project:
   flag to `git clone`.
   </summary>
   
-  Bats, however, uses submodules to load additional libraries,
+  Bats uses submodules to load additional libraries,
   like `bats-file` which provides assertions about files. Our use of Bats
   here include dependence on three Bats libraries as `git` sub-modules, and
   including the `--recurse-submodules` flag ensures that those Bats
-  dependencies will be properly included and your tests should run.
+  dependencies will be properly included. Without that your tests won't run.
+  See `testing/README.md` for more details.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -135,11 +135,17 @@ _on Github_ that belongs to you. You'll have full permissions on this copy so
 you can change the code, add collaborators, etc.
 
 <details>
-  <summary>:warning: Don't use "Use this template"</summary>
+  <summary>
+  
+  :warning: Don't use "Use this template"
+  
+  </summary>
+  
   Bats (and thus this project) depend heavily on `git` submodules, which
   don't work properly with GitHub templates. So make sure you use "Fork"
   instead of "Use this template" to create your copy of the repository
   on GitHub.
+
 </details>
 
 ### Add collaborators
@@ -182,15 +188,12 @@ Once that's all done you can clone the project:
 * In your terminal type `git clone --recurse-submodules <url>`, where `<url>` is the
   URL that you copied from Github.
 
-<details>
-  <summary>:information_source: You usually don't need the `--recurse-submodules` flag to
-`git clone`.</summary>
-  Bats, however, uses submodules to load additional libraries,
-  like `bats-file` which provides assertions about files. Our use of Bats
-  here include dependence on three Bats libraries as `git` sub-modules, and
-  including the `--recurse-submodules` flag ensures that those Bats
-  dependencies will be properly included and your tests should run.
-</details>
+:information_source: &nbsp; You usually don't need the `--recurse-submodules` flag to
+`git clone`. Bats, however, uses submodules to load additional libraries,
+like `bats-file` which provides assertions about files. Our use of Bats
+here include dependence on three Bats libraries as `git` sub-modules, and
+including the `--recurse-submodules` flag ensures that those Bats
+dependencies will be properly included and your tests should run.
 
 This should clone a working copy of your fork of the repo onto your computer.
 You should probably confirm that you got the directories and files on your

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,0 +1,38 @@
+# Bats testing support libraries
+
+This directory holds several Bats support libraries (such as `bats-file`) that
+are provided as [`git` submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules).
+
+To make sure these submodules get initialized properly when you check out the
+project used the `--recurse-submodules` flag to `git clone`, i.e.,
+
+```bash
+  git clone --recurse-submodules <repo URL>
+```
+
+If you've done that successfully you should never have any need to do anything
+in here. If, however, your Bats tests fail immediately with a message like:
+
+```english
+❯ bats bats_tests.sh
+bats: testing/bats-support/load does not exist
+/usr/local/lib/bats-core/tracing.bash: line 61: BATS_STACK_TRACE: bad array subscript
+ ✗
+   bats warning: Executed 1 instead of expected 9 tests
+
+9 tests, 1 failure, 8 not run
+```
+
+then you probably don't have your submodules initialized properly, probably
+because you forgot the `--recurse-submodules` flag. If that happens, you should
+be able to come into this directory and use
+
+```bash
+  git submodule update --init <module-name>
+```
+
+for each of the three modules:
+
+* `bats-assert`
+* `bats-file`
+* `bats-support`

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,7 +1,8 @@
 # Bats testing support libraries
 
-This directory holds several Bats support libraries (such as `bats-file`) that
-are provided as [`git` submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules).
+This directory holds (pointers to) several Bats support libraries
+(such as `bats-file`) that are provided as
+[`git` submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules).
 
 To make sure these submodules get initialized properly when you check out the
 project used the `--recurse-submodules` flag to `git clone`, i.e.,
@@ -11,7 +12,9 @@ project used the `--recurse-submodules` flag to `git clone`, i.e.,
 ```
 
 If you've done that successfully you should never have any need to do anything
-in here. If, however, your Bats tests fail immediately with a message like:
+in here.
+
+If, however, **your Bats tests fail immediately** with a message like:
 
 ```english
 ❯ bats bats_tests.sh
@@ -24,15 +27,11 @@ bats: testing/bats-support/load does not exist
 ```
 
 then you probably don't have your submodules initialized properly, probably
-because you forgot the `--recurse-submodules` flag. If that happens, you should
-be able to come into this directory and use
+because you forgot the `--recurse-submodules` flag. If that happens, the
+command
 
 ```bash
-  git submodule update --init <module-name>
+  git submodule update --init --recursive
 ```
 
-for each of the three modules:
-
-* `bats-assert`
-* `bats-file`
-* `bats-support`
+should correctly setup all the dependencies for you.


### PR DESCRIPTION
It looks like creating copies of repos via GitHub's template mechanism eats some important info about git sub-modules, and you're forced to re-add any templates by hand, which sucks.

Forking works, but I think that if you're using GitHub Classroom you have to use templates, so this is bit of a problem.

I sent the GitHub folks a question on this, and we'll see what (if anything) we get back.

Closes #16 