### PR TITLE
Fix shellcheck warnings

### DIFF
--- a/count_successes.sh
+++ b/count_successes.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+ls test_data

--- a/count_successes.sh
+++ b/count_successes.sh
@@ -1,3 +1,20 @@
 #!/usr/bin/bash
 
-echo "There were 78 successes and 22 failures." 
+# Extracts contents of a compressed tar archived specified as
+# the first command line argument and count the number of files
+# that contain the word "SUCCESS" and the number containing the word
+# "FAILURE" and reports that result.
+
+tar_file=$1
+
+SCRATCH=`mktemp --directory`
+
+tar zxf $tar_file --directory $SCRATCH
+
+num_successes=`grep -lr SUCCESS $SCRATCH | wc -l`
+
+num_failures=`grep -lr FAILURE $SCRATCH | wc -l`
+
+echo "There were $num_successes successes and $num_failures failures." 
+
+rm -rf $SCRATCH

--- a/count_successes.sh
+++ b/count_successes.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/bash
 
-echo "There were 347 successes and 70 failures." 
+echo "There were 78 successes and 22 failures." 

--- a/count_successes.sh
+++ b/count_successes.sh
@@ -9,11 +9,11 @@ tar_file=$1
 
 SCRATCH=$(mktemp --directory)
 
-tar zxf $tar_file --directory $SCRATCH
+tar zxf "$tar_file" --directory "$SCRATCH"
 
-num_successes=$(grep -lr SUCCESS $SCRATCH | wc -l)
+num_successes=$(grep -lr SUCCESS "$SCRATCH" | wc -l)
 
-num_failures=$(grep -lr FAILURE $SCRATCH | wc -l)
+num_failures=$(grep -lr FAILURE "$SCRATCH" | wc -l)
 
 echo "There were $num_successes successes and $num_failures failures." 
 

--- a/count_successes.sh
+++ b/count_successes.sh
@@ -7,14 +7,14 @@
 
 tar_file=$1
 
-SCRATCH=`mktemp --directory`
+SCRATCH=$(mktemp --directory)
 
 tar zxf $tar_file --directory $SCRATCH
 
-num_successes=`grep -lr SUCCESS $SCRATCH | wc -l`
+num_successes=$(grep -lr SUCCESS $SCRATCH | wc -l)
 
-num_failures=`grep -lr FAILURE $SCRATCH | wc -l`
+num_failures=$(grep -lr FAILURE $SCRATCH | wc -l)
 
 echo "There were $num_successes successes and $num_failures failures." 
 
-rm -rf $SCRATCH
+rm -rf "$SCRATCH"

--- a/count_successes.sh
+++ b/count_successes.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 # Extracts contents of a compressed tar archived specified as
 # the first command line argument and count the number of files

--- a/count_successes.sh
+++ b/count_successes.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/bash
 
-ls test_data
+echo "There were 347 successes and 70 failures." 

--- a/test_data/files/output_file_0.txt
+++ b/test_data/files/output_file_0.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_1.txt
+++ b/test_data/files/output_file_1.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_10.txt
+++ b/test_data/files/output_file_10.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_11.txt
+++ b/test_data/files/output_file_11.txt
@@ -1,0 +1,1 @@
+FAILURE

--- a/test_data/files/output_file_12.txt
+++ b/test_data/files/output_file_12.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_13.txt
+++ b/test_data/files/output_file_13.txt
@@ -1,0 +1,1 @@
+FAILURE

--- a/test_data/files/output_file_14.txt
+++ b/test_data/files/output_file_14.txt
@@ -1,0 +1,1 @@
+FAILURE

--- a/test_data/files/output_file_15.txt
+++ b/test_data/files/output_file_15.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_16.txt
+++ b/test_data/files/output_file_16.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_17.txt
+++ b/test_data/files/output_file_17.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_18.txt
+++ b/test_data/files/output_file_18.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_19.txt
+++ b/test_data/files/output_file_19.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_2.txt
+++ b/test_data/files/output_file_2.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_20.txt
+++ b/test_data/files/output_file_20.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_21.txt
+++ b/test_data/files/output_file_21.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_22.txt
+++ b/test_data/files/output_file_22.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_23.txt
+++ b/test_data/files/output_file_23.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_24.txt
+++ b/test_data/files/output_file_24.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_25.txt
+++ b/test_data/files/output_file_25.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_26.txt
+++ b/test_data/files/output_file_26.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_27.txt
+++ b/test_data/files/output_file_27.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_28.txt
+++ b/test_data/files/output_file_28.txt
@@ -1,0 +1,1 @@
+FAILURE

--- a/test_data/files/output_file_29.txt
+++ b/test_data/files/output_file_29.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_3.txt
+++ b/test_data/files/output_file_3.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_30.txt
+++ b/test_data/files/output_file_30.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_31.txt
+++ b/test_data/files/output_file_31.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_32.txt
+++ b/test_data/files/output_file_32.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_33.txt
+++ b/test_data/files/output_file_33.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_34.txt
+++ b/test_data/files/output_file_34.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_35.txt
+++ b/test_data/files/output_file_35.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_36.txt
+++ b/test_data/files/output_file_36.txt
@@ -1,0 +1,1 @@
+FAILURE

--- a/test_data/files/output_file_37.txt
+++ b/test_data/files/output_file_37.txt
@@ -1,0 +1,1 @@
+FAILURE

--- a/test_data/files/output_file_38.txt
+++ b/test_data/files/output_file_38.txt
@@ -1,0 +1,1 @@
+FAILURE

--- a/test_data/files/output_file_39.txt
+++ b/test_data/files/output_file_39.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_4.txt
+++ b/test_data/files/output_file_4.txt
@@ -1,0 +1,1 @@
+FAILURE

--- a/test_data/files/output_file_40.txt
+++ b/test_data/files/output_file_40.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_41.txt
+++ b/test_data/files/output_file_41.txt
@@ -1,0 +1,1 @@
+FAILURE

--- a/test_data/files/output_file_42.txt
+++ b/test_data/files/output_file_42.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_43.txt
+++ b/test_data/files/output_file_43.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_44.txt
+++ b/test_data/files/output_file_44.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_45.txt
+++ b/test_data/files/output_file_45.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_46.txt
+++ b/test_data/files/output_file_46.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_47.txt
+++ b/test_data/files/output_file_47.txt
@@ -1,0 +1,1 @@
+FAILURE

--- a/test_data/files/output_file_48.txt
+++ b/test_data/files/output_file_48.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_49.txt
+++ b/test_data/files/output_file_49.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_5.txt
+++ b/test_data/files/output_file_5.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_50.txt
+++ b/test_data/files/output_file_50.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_51.txt
+++ b/test_data/files/output_file_51.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_52.txt
+++ b/test_data/files/output_file_52.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_53.txt
+++ b/test_data/files/output_file_53.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_54.txt
+++ b/test_data/files/output_file_54.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_55.txt
+++ b/test_data/files/output_file_55.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_56.txt
+++ b/test_data/files/output_file_56.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_57.txt
+++ b/test_data/files/output_file_57.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_58.txt
+++ b/test_data/files/output_file_58.txt
@@ -1,0 +1,1 @@
+FAILURE

--- a/test_data/files/output_file_59.txt
+++ b/test_data/files/output_file_59.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_6.txt
+++ b/test_data/files/output_file_6.txt
@@ -1,0 +1,1 @@
+FAILURE

--- a/test_data/files/output_file_60.txt
+++ b/test_data/files/output_file_60.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_61.txt
+++ b/test_data/files/output_file_61.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_62.txt
+++ b/test_data/files/output_file_62.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_63.txt
+++ b/test_data/files/output_file_63.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_64.txt
+++ b/test_data/files/output_file_64.txt
@@ -1,0 +1,1 @@
+FAILURE

--- a/test_data/files/output_file_65.txt
+++ b/test_data/files/output_file_65.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_66.txt
+++ b/test_data/files/output_file_66.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_67.txt
+++ b/test_data/files/output_file_67.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_68.txt
+++ b/test_data/files/output_file_68.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_69.txt
+++ b/test_data/files/output_file_69.txt
@@ -1,0 +1,1 @@
+FAILURE

--- a/test_data/files/output_file_7.txt
+++ b/test_data/files/output_file_7.txt
@@ -1,0 +1,1 @@
+FAILURE

--- a/test_data/files/output_file_70.txt
+++ b/test_data/files/output_file_70.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_71.txt
+++ b/test_data/files/output_file_71.txt
@@ -1,0 +1,1 @@
+FAILURE

--- a/test_data/files/output_file_72.txt
+++ b/test_data/files/output_file_72.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_73.txt
+++ b/test_data/files/output_file_73.txt
@@ -1,0 +1,1 @@
+FAILURE

--- a/test_data/files/output_file_74.txt
+++ b/test_data/files/output_file_74.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_75.txt
+++ b/test_data/files/output_file_75.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_76.txt
+++ b/test_data/files/output_file_76.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_77.txt
+++ b/test_data/files/output_file_77.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_78.txt
+++ b/test_data/files/output_file_78.txt
@@ -1,0 +1,1 @@
+FAILURE

--- a/test_data/files/output_file_79.txt
+++ b/test_data/files/output_file_79.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_8.txt
+++ b/test_data/files/output_file_8.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_80.txt
+++ b/test_data/files/output_file_80.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_81.txt
+++ b/test_data/files/output_file_81.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_82.txt
+++ b/test_data/files/output_file_82.txt
@@ -1,0 +1,1 @@
+FAILURE

--- a/test_data/files/output_file_83.txt
+++ b/test_data/files/output_file_83.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_84.txt
+++ b/test_data/files/output_file_84.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_85.txt
+++ b/test_data/files/output_file_85.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_86.txt
+++ b/test_data/files/output_file_86.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_87.txt
+++ b/test_data/files/output_file_87.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_88.txt
+++ b/test_data/files/output_file_88.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_89.txt
+++ b/test_data/files/output_file_89.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_9.txt
+++ b/test_data/files/output_file_9.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_90.txt
+++ b/test_data/files/output_file_90.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_91.txt
+++ b/test_data/files/output_file_91.txt
@@ -1,0 +1,1 @@
+FAILURE

--- a/test_data/files/output_file_92.txt
+++ b/test_data/files/output_file_92.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_93.txt
+++ b/test_data/files/output_file_93.txt
@@ -1,0 +1,1 @@
+FAILURE

--- a/test_data/files/output_file_94.txt
+++ b/test_data/files/output_file_94.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_95.txt
+++ b/test_data/files/output_file_95.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_96.txt
+++ b/test_data/files/output_file_96.txt
@@ -1,0 +1,1 @@
+FAILURE

--- a/test_data/files/output_file_97.txt
+++ b/test_data/files/output_file_97.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_98.txt
+++ b/test_data/files/output_file_98.txt
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test_data/files/output_file_99.txt
+++ b/test_data/files/output_file_99.txt
@@ -1,0 +1,1 @@
+SUCCESS


### PR DESCRIPTION
This fixes all the warnings from `shellchecks` and updates the shebang to use `/usr/bin/env bash` for added portability.